### PR TITLE
Add AWS CLI credential_process compatible JSON output

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,13 @@ Now your keys are stored safely in the macOS keychain. To print environment vari
 
     awskeyring env personal-aws
 
-See below and in the wiki for more details on usage.
+Alternatively you can create a profile using the credential_process config variable. See the [AWS CLI Config docs](http://docs.aws.amazon.com/cli/latest/topic/config-vars.html#cli-aws-help-config-vars) for more details on this config option.
+
+    [profile personal]
+    region = us-west-1
+    credential_process = awskeyring json personal-aws 
+
+See below and in the [wiki](https://github.com/vibrato/awskeyring/wiki) for more details on usage.
 
 ## Installation
 
@@ -53,6 +59,7 @@ The CLI is using [Thor](http://whatisthor.com) with help provided interactively.
       awskeyring exec ACCOUNT command...     # Execute a COMMAND with the environment set for an ACCOUNT
       awskeyring help [COMMAND]              # Describe available commands or one specific command
       awskeyring initialise                  # Initialises a new KEYCHAIN
+      awskeyring json ACCOUNT                # Outputs AWS CLI compatible JSON for an ACCOUNT
       awskeyring list                        # Prints a list of accounts in the keyring
       awskeyring list-role                   # Prints a list of roles in the keyring
       awskeyring remove ACCOUNT              # Removes an ACCOUNT from the keyring
@@ -73,7 +80,7 @@ To set your environment easily the following bash function helps:
 
 After checking out the repo, run `bundle update` to install dependencies. Then, run `rake` to run the tests. Run `bundle exec awskeyring` to use the gem in this directory, ignoring other installed copies of this gem.
 
-To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
+To install this gem onto your local machine, run `bundle exec rake install`.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ See below and in the wiki for more details on usage.
 
 Install it with:
 
-    $ gem install awskeyring
+    $ gem install awskeyring --user-install
 
 ## Usage
 

--- a/lib/awskeyring.rb
+++ b/lib/awskeyring.rb
@@ -162,11 +162,13 @@ module Awskeyring # rubocop:disable Metrics/ModuleLength
   def self.get_valid_creds(account:)
     cred, temp_cred = get_valid_item_pair(account: account)
     token = temp_cred.password unless temp_cred.nil?
+    expiry = temp_cred.attributes[:account].to_i unless temp_cred.nil?
     {
       account: account,
       key: cred.attributes[:account],
       secret: cred.password,
-      token: token
+      token: token,
+      expiry: expiry
     }
   end
 

--- a/lib/awskeyring/awsapi.rb
+++ b/lib/awskeyring/awsapi.rb
@@ -61,6 +61,24 @@ module Awskeyring
       }
     end
 
+    # Genarates AWS CLI compatible JSON
+    # see credential_process in AWS Docs
+    #
+    # @param [String] key The aws_access_key_id
+    # @param [String] secret The aws_secret_access_key
+    # @param [String] token The aws_session_token
+    # @param [String] expiry expiry time
+    # @return [String] credential_process json
+    def self.get_cred_json(key:, secret:, token:, expiry:)
+      JSON.pretty_generate(
+        Version: 1,
+        AccessKeyId: key,
+        SecretAccessKey: secret,
+        SessionToken: token,
+        Expiration: expiry
+      )
+    end
+
     # Retrieves an AWS Console login url
     #
     # @param [String] key The aws_access_key_id

--- a/lib/awskeyring/awsapi.rb
+++ b/lib/awskeyring/awsapi.rb
@@ -49,7 +49,7 @@ module Awskeyring
             )
           end
       rescue Aws::STS::Errors::AccessDenied => err
-        puts err.to_s
+        warn err.to_s
         exit 1
       end
 

--- a/lib/awskeyring_command.rb
+++ b/lib/awskeyring_command.rb
@@ -76,6 +76,22 @@ class AwskeyringCommand < Thor # rubocop:disable Metrics/ClassLength
     )
   end
 
+  desc 'json ACCOUNT', 'Outputs AWS CLI compatible JSON for an ACCOUNT'
+  # Print JSON for use with credential_process
+  def json(account = nil)
+    account = ask_check(
+      existing: account, message: 'account name', validator: Awskeyring::Validate.method(:account_name)
+    )
+    cred = Awskeyring.get_valid_creds(account: account)
+    expiry = Time.at(cred[:expiry]) unless cred[:expiry].nil?
+    puts Awskeyring::Awsapi.get_cred_json(
+      key: cred[:key],
+      secret: cred[:secret],
+      token: cred[:token],
+      expiry: expiry || Time.new + 3600
+    )
+  end
+
   desc 'exec ACCOUNT command...', 'Execute a COMMAND with the environment set for an ACCOUNT'
   # execute an external command with env set
   def exec(account, *command)

--- a/spec/lib/awskeyring/awsapi_spec.rb
+++ b/spec/lib/awskeyring/awsapi_spec.rb
@@ -105,6 +105,21 @@ describe Awskeyring::Awsapi do
         expiry: Time.parse('2011-07-11T19:55:29.611Z')
       )
     end
+
+    it 'returns a JSON formatted Credential' do
+      expect(subject.get_cred_json(
+               key: 'ASIAIOSFODNN7EXAMPLE',
+               secret: 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYzEXAMPLEKEY',
+               token: role_token,
+               expiry: Time.parse('2011-07-11T19:55:29.611Z')
+      )).to eq(%({
+  "Version": 1,
+  "AccessKeyId": "ASIAIOSFODNN7EXAMPLE",
+  "SecretAccessKey": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYzEXAMPLEKEY",
+  "SessionToken": "AQoDYXdzEPT//////////wEXAMPLEtc764assume_roleDOk4x4HIZ8j4FZTwdQWLWsKWHGBuFqwAeMi",
+  "Expiration": "2011-07-11 19:55:29 UTC"
+}))
+    end
   end
 
   context 'When we try to access AWS Console' do

--- a/spec/lib/awskeyring_spec.rb
+++ b/spec/lib/awskeyring_spec.rb
@@ -68,7 +68,8 @@ describe Awskeyring do
         account: 'test',
         key: 'AKIATESTTEST',
         secret: 'biglongbase64',
-        token: nil
+        token: nil,
+        expiry: nil
       )
       expect(subject.get_account_hash(account: 'test')).to eq(
         account: 'test',
@@ -124,7 +125,7 @@ describe Awskeyring do
     end
     let(:session_token) do
       double(
-        attributes: { label: 'session-token test', account: 0 },
+        attributes: { label: 'session-token test', account: Time.parse('2016-12-01T22:20:01Z').to_i.to_s },
         password: 'evenlongerbase64token'
       )
     end
@@ -153,7 +154,8 @@ describe Awskeyring do
         account: 'test',
         key: 'ASIATESTTEST',
         secret: 'bigerlongbase64',
-        token: 'evenlongerbase64token'
+        token: 'evenlongerbase64token',
+        expiry: Time.parse('2016-12-01T22:20:01Z').to_i
       )
       expect(subject.get_account_hash(account: 'test')).to eq(
         account: 'test',


### PR DESCRIPTION
This allow you to access your credentials in the aws-cli without them being set as environment variables.