### PR TITLE
Adds no token flag to skip saved token

### DIFF
--- a/lib/awskeyring.rb
+++ b/lib/awskeyring.rb
@@ -164,8 +164,13 @@ module Awskeyring # rubocop:disable Metrics/ModuleLength
   end
 
   # Return valid creds for account
-  def self.get_valid_creds(account:)
-    cred, temp_cred = get_valid_item_pair(account: account)
+  def self.get_valid_creds(account:, no_token: false)
+    if no_token
+      cred = get_item(account: account)
+      temp_cred = nil
+    else
+      cred, temp_cred = get_valid_item_pair(account: account)
+    end
     token = temp_cred.password unless temp_cred.nil?
     expiry = temp_cred.attributes[:account].to_i unless temp_cred.nil?
     {

--- a/lib/awskeyring_command.rb
+++ b/lib/awskeyring_command.rb
@@ -62,12 +62,13 @@ class AwskeyringCommand < Thor # rubocop:disable Metrics/ClassLength
   end
 
   desc 'env ACCOUNT', 'Outputs bourne shell environment exports for an ACCOUNT'
+  method_option 'no-token', type: :boolean, aliases: '-n', desc: 'Do not use saved token.', default: false
   # Print Env vars
   def env(account = nil)
     account = ask_check(
       existing: account, message: 'account name', validator: Awskeyring::Validate.method(:account_name)
     )
-    cred = Awskeyring.get_valid_creds(account: account)
+    cred = Awskeyring.get_valid_creds(account: account, no_token: options['no-token'])
     age_check(account, cred[:updated])
     put_env_string(
       account: cred[:account],
@@ -78,12 +79,13 @@ class AwskeyringCommand < Thor # rubocop:disable Metrics/ClassLength
   end
 
   desc 'json ACCOUNT', 'Outputs AWS CLI compatible JSON for an ACCOUNT'
+  method_option 'no-token', type: :boolean, aliases: '-n', desc: 'Do not use saved token.', default: false
   # Print JSON for use with credential_process
   def json(account = nil)
     account = ask_check(
       existing: account, message: 'account name', validator: Awskeyring::Validate.method(:account_name)
     )
-    cred = Awskeyring.get_valid_creds(account: account)
+    cred = Awskeyring.get_valid_creds(account: account, no_token: options['no-token'])
     age_check(account, cred[:updated])
     expiry = Time.at(cred[:expiry]) unless cred[:expiry].nil?
     puts Awskeyring::Awsapi.get_cred_json(
@@ -95,9 +97,10 @@ class AwskeyringCommand < Thor # rubocop:disable Metrics/ClassLength
   end
 
   desc 'exec ACCOUNT command...', 'Execute a COMMAND with the environment set for an ACCOUNT'
+  method_option 'no-token', type: :boolean, aliases: '-n', desc: 'Do not use saved token.', default: false
   # execute an external command with env set
   def exec(account, *command)
-    cred = Awskeyring.get_valid_creds(account: account)
+    cred = Awskeyring.get_valid_creds(account: account, no_token: options['no-token'])
     age_check(account, cred[:updated])
     env_vars = env_vars(
       account: cred[:account],
@@ -284,12 +287,13 @@ class AwskeyringCommand < Thor # rubocop:disable Metrics/ClassLength
 
   desc 'console ACCOUNT', 'Open the AWS Console for the ACCOUNT'
   method_option :path, type: :string, aliases: '-p', desc: 'The service PATH to open.'
+  method_option 'no-token', type: :boolean, aliases: '-n', desc: 'Do not use saved token.', default: false
   # Open the AWS Console
-  def console(account = nil) # rubocop:disable Metrics/MethodLength
+  def console(account = nil) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
     account = ask_check(
       existing: account, message: 'account name', validator: Awskeyring::Validate.method(:account_name)
     )
-    cred = Awskeyring.get_valid_creds(account: account)
+    cred = Awskeyring.get_valid_creds(account: account, no_token: options['no-token'])
     age_check(account, cred[:updated])
 
     path = options[:path] || 'console'

--- a/lib/awskeyring_command.rb
+++ b/lib/awskeyring_command.rb
@@ -343,7 +343,7 @@ class AwskeyringCommand < Thor # rubocop:disable Metrics/ClassLength
   def print_auto_resp(curr, len)
     case len
     when 0
-      puts list_commands.select { |elem| elem.start_with?(curr) }.join("\n")
+      puts list_commands.select { |elem| elem.start_with?(curr) }.sort.join("\n")
     when 1
       puts Awskeyring.list_account_names.select { |elem| elem.start_with?(curr) }.join("\n")
     when 2
@@ -354,7 +354,7 @@ class AwskeyringCommand < Thor # rubocop:disable Metrics/ClassLength
   end
 
   def list_commands
-    self.class.all_commands.keys.map { |elem| elem.tr('_', '-') }
+    self.class.all_commands.keys.map { |elem| elem.tr('_', '-') }.reject { |elem| elem == 'awskeyring' }
   end
 
   def env_vars(account:, key:, secret:, token:)

--- a/spec/lib/awskeyring_command_spec.rb
+++ b/spec/lib/awskeyring_command_spec.rb
@@ -67,6 +67,13 @@ describe AwskeyringCommand do
         .to output("minion\n").to_stdout
       ENV['COMP_LINE'] = nil
     end
+
+    it 'lists commands with autocomplete' do
+      ENV['COMP_LINE'] = 'awskeyring '
+      expect { AwskeyringCommand.start(['awskeyring', '', 'awskeyring']) }
+        .to output(/--version\nadd\nadd-role\nconsole\nenv\nexec\nhelp/).to_stdout
+      ENV['COMP_LINE'] = nil
+    end
   end
 
   context 'When there is an account and a role' do

--- a/spec/lib/awskeyring_more_command_spec.rb
+++ b/spec/lib/awskeyring_more_command_spec.rb
@@ -5,7 +5,7 @@ require_relative '../../lib/awskeyring_command'
 describe AwskeyringCommand do
   context 'When we try to access AWS with a token' do
     before do
-      allow(Awskeyring).to receive(:get_valid_creds).with(account: 'test').and_return(
+      allow(Awskeyring).to receive(:get_valid_creds).with(account: 'test', no_token: false).and_return(
         account: 'test',
         key: 'ASIATESTTEST',
         secret: 'bigerlongbase64',
@@ -19,7 +19,7 @@ describe AwskeyringCommand do
     end
 
     it 'opens the AWS Console' do
-      expect(Awskeyring).to receive(:get_valid_creds).with(account: 'test')
+      expect(Awskeyring).to receive(:get_valid_creds).with(account: 'test', no_token: false)
       expect(Awskeyring::Awsapi).to receive(:get_login_url).with(
         key: 'ASIATESTTEST',
         secret: 'bigerlongbase64',
@@ -34,7 +34,7 @@ describe AwskeyringCommand do
 
   context 'When we try to access AWS without a token' do
     before do
-      allow(Awskeyring).to receive(:get_valid_creds).with(account: 'test').and_return(
+      allow(Awskeyring).to receive(:get_valid_creds).with(account: 'test', no_token: false).and_return(
         account: 'test',
         key: 'AKIATESTTEST',
         secret: 'biglongbase64',
@@ -48,7 +48,7 @@ describe AwskeyringCommand do
     end
 
     it 'opens the AWS Console' do
-      expect(Awskeyring).to receive(:get_valid_creds).with(account: 'test')
+      expect(Awskeyring).to receive(:get_valid_creds).with(account: 'test', no_token: false)
       expect(Awskeyring::Awsapi).to receive(:get_login_url).with(
         key: 'AKIATESTTEST',
         secret: 'biglongbase64',
@@ -304,7 +304,7 @@ describe AwskeyringCommand do
         mfa: nil,
         updated: Time.parse('2016-12-01T22:20:01Z')
       )
-      allow(Awskeyring).to receive(:get_valid_creds).with(account: 'test').and_return(
+      allow(Awskeyring).to receive(:get_valid_creds).and_return(
         account: 'test',
         key: 'AKIAIOSFODNN7EXAMPLE',
         secret: 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYzEXAMPLEKEY',

--- a/spec/lib/awskeyring_spec.rb
+++ b/spec/lib/awskeyring_spec.rb
@@ -183,6 +183,17 @@ describe Awskeyring do
       )
     end
 
+    it 'returns a hash with the only the creds' do
+      expect(subject.get_valid_creds(account: 'test', no_token: true)).to eq(
+        account: 'test',
+        key: 'AKIATESTTEST',
+        secret: 'biglongbase64',
+        token: nil,
+        expiry: nil,
+        updated: Time.parse('2016-12-01T22:20:01Z')
+      )
+    end
+
     it 'returns a hash with the role' do
       expect(subject.get_role_arn(role_name: 'role')).to eq(
         'arn:aws:iam::012345678901:role/test'


### PR DESCRIPTION
Adds a --no-token flag to console, env, exec and json. useful when you don't want to use the saved token but also don't want to remove-token it just yet.

P.S. also a tweak for auto-complete.