### PR TITLE
Fix JSON time format to use ISO8601.

### DIFF
--- a/lib/awskeyring_command.rb
+++ b/lib/awskeyring_command.rb
@@ -92,7 +92,7 @@ class AwskeyringCommand < Thor # rubocop:disable Metrics/ClassLength
       key: cred[:key],
       secret: cred[:secret],
       token: cred[:token],
-      expiry: expiry || Time.new + Awskeyring::Awsapi::ONE_HOUR
+      expiry: (expiry || Time.new + Awskeyring::Awsapi::ONE_HOUR).iso8601
     )
   end
 

--- a/spec/lib/awskeyring_command_spec.rb
+++ b/spec/lib/awskeyring_command_spec.rb
@@ -219,7 +219,7 @@ unset AWS_SESSION_TOKEN
           AccessKeyId: 'ASIATESTTEST',
           SecretAccessKey: 'bigerlongbase64',
           SessionToken: 'evenlongerbase64token',
-          Expiration: Time.at(Time.parse('2011-07-11T19:55:29.611Z').to_i)
+          Expiration: Time.at(Time.parse('2011-07-11T19:55:29.611Z').to_i).iso8601
         ) + "\n").to_stdout
     end
 


### PR DESCRIPTION
Was not using the correct time format as expected by the aws-sdk (for ruby) before.