### PR TITLE
Use a default Region for Rotate.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Alternatively you can create a profile using the credential_process config varia
 
     [profile personal]
     region = us-west-1
-    credential_process = awskeyring json personal-aws 
+    credential_process = /usr/local/bin/awskeyring json personal-aws
 
 See below and in the [wiki](https://github.com/vibrato/awskeyring/wiki) for more details on usage.
 

--- a/lib/awskeyring/awsapi.rb
+++ b/lib/awskeyring/awsapi.rb
@@ -182,7 +182,8 @@ module Awskeyring
     # @return [String] key The aws_access_key_id
     # @return [String] secret The aws_secret_access_key
     # @return [String] account the associated account name.
-    def self.rotate(account:, key:, secret:, key_message:) # rubocop:disable  Metrics/MethodLength
+    def self.rotate(account:, key:, secret:, key_message:) # rubocop:disable  Metrics/MethodLength, Metrics/AbcSize
+      ENV['AWS_DEFAULT_REGION'] = 'us-east-1' unless region
       iam = Aws::IAM::Client.new(access_key_id: key, secret_access_key: secret)
 
       if iam.list_access_keys[:access_key_metadata].length > 1

--- a/spec/lib/awskeyring_command_spec.rb
+++ b/spec/lib/awskeyring_command_spec.rb
@@ -110,6 +110,7 @@ describe AwskeyringCommand do
         updated: Time.parse('2011-08-11T22:20:01Z')
       )
       allow(Time).to receive(:new).and_return(Time.parse('2011-07-11T19:55:29.611Z'))
+      allow(Awskeyring::Awsapi).to receive(:region).and_return(nil)
     end
 
     it 'removes an account' do
@@ -125,9 +126,9 @@ describe AwskeyringCommand do
     it 'export an AWS Access key' do
       expect(Awskeyring).to receive(:get_valid_creds).with(account: 'test', no_token: false)
 
-      ENV['AWS_DEFAULT_REGION'] = 'us-east-1'
       expect { AwskeyringCommand.start(%w[env test]) }
-        .to output(%(export AWS_ACCOUNT_NAME="test"
+        .to output(%(export AWS_DEFAULT_REGION="us-east-1"
+export AWS_ACCOUNT_NAME="test"
 export AWS_ACCESS_KEY_ID="AKIATESTTEST"
 export AWS_ACCESS_KEY="AKIATESTTEST"
 export AWS_SECRET_ACCESS_KEY="biglongbase64"
@@ -150,8 +151,7 @@ unset AWS_SESSION_TOKEN
         'AWS_SESSION_TOKEN' => 'evenlongerbase64token' }
     end
     before do
-      ENV['AWS_DEFAULT_REGION'] = nil
-      ENV['AWS_REGION'] = nil
+      allow(Awskeyring::Awsapi).to receive(:region).and_return(nil)
       allow(Awskeyring).to receive(:delete_token)
       allow(Awskeyring).to receive(:get_valid_creds).with(account: 'test', no_token: false).and_return(
         account: 'test',

--- a/spec/lib/awskeyring_more_command_spec.rb
+++ b/spec/lib/awskeyring_more_command_spec.rb
@@ -311,7 +311,6 @@ describe AwskeyringCommand do
 
   context 'when we try to rotate keys' do
     before do
-      ENV['AWS_DEFAULT_REGION'] = nil
       allow(Awskeyring).to receive(:get_valid_creds).and_return(
         account: 'test',
         key: 'AKIAIOSFODNN7EXAMPLE',
@@ -364,7 +363,6 @@ describe AwskeyringCommand do
     end
 
     before do
-      ENV['AWS_DEFAULT_REGION'] = 'us-east-1'
       allow(Awskeyring).to receive(:get_valid_creds).and_return(
         account: 'test',
         key: 'AKIAIOSFODNN7EXAMPLE',


### PR DESCRIPTION
fixes some tests when using a default profile in ~/.aws/config