### PR TITLE
Trailing LF was being passed to validator

### DIFF
--- a/lib/awskeyring_command.rb
+++ b/lib/awskeyring_command.rb
@@ -461,7 +461,7 @@ class AwskeyringCommand < Thor # rubocop:disable Metrics/ClassLength
 
   def ask(message:, secure: false, optional: false)
     if secure
-      Thor::LineEditor.readline(message.rjust(20) + ': ', echo: false)
+      Thor::LineEditor.readline(message.rjust(20) + ': ', echo: false).strip
     elsif optional
       Thor::LineEditor.readline((message + ' (optional)').rjust(20) + ': ')
     else


### PR DESCRIPTION
Related to #36 , For some reason a trailing line-feed character was being passed with the secret token string to the validation code. this fixes the immediate issue of the input failing. The feedback will be addressed in a later commit and release.