### PR TITLE
Check for COMMAND param to exec.

### DIFF
--- a/i18n/en.yml
+++ b/i18n/en.yml
@@ -68,6 +68,7 @@ en:
     delrole: '# Removing role %{role}'
     deltoken: '# Removing token for account %{account}'
     delexpired: '# Removing expired session credentials'
+    exec: '# COMMAND not provided'
     missing: '# Config missing, run `%{bin} initialise` to recreate.'
     rotate: '# You have two access keys for account %{account}'
     temporary: '# Using temporary session credentials.'

--- a/spec/lib/awskeyring_command_spec.rb
+++ b/spec/lib/awskeyring_command_spec.rb
@@ -236,5 +236,12 @@ unset AWS_SESSION_TOKEN
       )
       AwskeyringCommand.start(%w[exec test test-exec with params])
     end
+
+    it 'warns about a missing external command' do
+      expect(Process).to_not receive(:spawn)
+      expect do
+        AwskeyringCommand.start(%w[exec test])
+      end.to raise_error(SystemExit).and output(/COMMAND not provided/).to_stderr
+    end
   end
 end


### PR DESCRIPTION
Handles cases of forgetting or using an invalid command with the awskeyring exec sub-command.