### PR TITLE
Fix usage behind PROXIES

### DIFF
--- a/lib/awskeyring/awsapi.rb
+++ b/lib/awskeyring/awsapi.rb
@@ -159,7 +159,10 @@ module Awskeyring
       get_signin_token_url = AWS_SIGNIN_URL + '?Action=getSigninToken' \
                              '&Session=' + CGI.escape(session_json)
 
-      returned_content = Net::HTTP.get(URI.parse(get_signin_token_url))
+      uri       = URI(get_signin_token_url)
+      request   = Net::HTTP.new(uri.host, uri.port)
+      request.use_ssl = true
+      returned_content = request.get(uri).body
 
       signin_token = JSON.parse(returned_content)['SigninToken']
       '&SigninToken=' + CGI.escape(signin_token)

--- a/spec/lib/awskeyring/awsapi_spec.rb
+++ b/spec/lib/awskeyring/awsapi_spec.rb
@@ -176,7 +176,12 @@ describe Awskeyring::Awsapi do
             }
           )
         )
-      allow(Net::HTTP).to receive(:get).and_return('{"SigninToken":"*** the SigninToken string ***"}')
+      allow_any_instance_of(Net::HTTP).to receive(:get)
+        .and_return(
+          double(
+            body: '{"SigninToken":"*** the SigninToken string ***"}'
+          )
+        )
     end
 
     it 'return a login_url to the AWS Console' do


### PR DESCRIPTION
Seems the default Net::HTTP.get doesn't recognise proxy env vars. This uses a different code path to pickup the proxy settings if in the env. 