### PR TITLE
Unfreeze secret strings.

### DIFF
--- a/lib/awskeyring/input.rb
+++ b/lib/awskeyring/input.rb
@@ -15,7 +15,7 @@ module Awskeyring
     end
 
     private_class_method def self.hide_input # rubocop:disable Metrics/MethodLength
-      password = ''
+      password = +''
       loop do
         character = $stdin.getch
         break unless character

--- a/spec/lib/awskeyring/input_spec.rb
+++ b/spec/lib/awskeyring/input_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require_relative '../../../lib/awskeyring/input'
+
+describe Awskeyring::Input do
+  context 'when inputting a secret key' do
+    before do
+      allow(STDIN).to receive(:getch).and_return('A', 'B', 'C', '1', '2', '3', "\n")
+    end
+
+    it 'asks for a secret' do
+      expect do
+        subject.read_secret('   secret access key: ')
+      end.to output("   secret access key: ******\n").to_stdout
+    end
+  end
+end


### PR DESCRIPTION
Fixes can't modify frozen String when entering a secret.